### PR TITLE
update python version used in rust image

### DIFF
--- a/rust-cross.dockerfile
+++ b/rust-cross.dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.77.0-slim-bullseye
+FROM rust:1.77.0-slim-bookworm
 
 RUN apt update && apt upgrade -y && \
     apt install -y git curl clang llvm xz-utils python3-venv python3-pip


### PR DESCRIPTION
- Update image used from rust for docker -  the new image uses python 3.10 which is compatible with the sim project. 
- Successful builds using this image can be seen here: 
    - https://bitbucket.org/f50league/sgpsim_core/pipelines/results/102
    - https://bitbucket.org/f50league/sgpsim_core/pipelines/results/101
- I propose merging this and pushing a new image laskew/rust-cross:1.77-5